### PR TITLE
Notify when blocker is assigned to nobody@mozilla.org

### DIFF
--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -74,6 +74,7 @@ module.exports = (robot) => {
           bug_severity: 'blocker',
           resolution: '---',
           bug_status: ['NEW', 'REOPENED'],
+          assigned_to: encodeURIComponent('nobody@mozilla.org'),
           priority: ['--', 'P1', 'P2'],
         });
 


### PR DESCRIPTION
Right now when a blocker is assigned to someone, the bot will continue to alert the channel until someone changes the status to something other than `NEW` or `REOPENED`. This PR modifies the API call to add a query for `assigned_to`.