### PR TITLE
add more specific useragent and make bugzilla requests faster

### DIFF
--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -76,6 +76,7 @@ module.exports = (robot) => {
           bug_status: ['NEW', 'REOPENED'],
           assigned_to: encodeURIComponent('nobody@mozilla.org'),
           priority: ['--', 'P1', 'P2'],
+          include_fields: ['summary', 'bug_id'],
         });
 
         if (!bugs.length) {

--- a/src/utils/blockers.js
+++ b/src/utils/blockers.js
@@ -1,7 +1,12 @@
 const got = require('got');
+const client = got.extend({
+  headers: {
+    'user-agent': 'hubot-irc-alert (https://github.com/taskcluster/hubot-irc-alert)'
+  }
+});
 
 module.exports = async (query) => {
-  const { body: { bugs } } = await got.get(`${process.env.BUGZILLA_BASE_URL}/rest/bug`, {
+  const { body: { bugs } } = await client.get(`${process.env.BUGZILLA_BASE_URL}/rest/bug`, {
     json: true,
     query,
   });

--- a/src/utils/blockers.js
+++ b/src/utils/blockers.js
@@ -1,12 +1,10 @@
 const got = require('got');
-const client = got.extend({
-  headers: {
-    'user-agent': 'hubot-irc-alert (https://github.com/taskcluster/hubot-irc-alert)'
-  }
-});
 
 module.exports = async (query) => {
-  const { body: { bugs } } = await client.get(`${process.env.BUGZILLA_BASE_URL}/rest/bug`, {
+  const { body: { bugs } } = await got.get(`${process.env.BUGZILLA_BASE_URL}/rest/bug`, {
+    headers: {
+      'user-agent': 'hubot-irc-alert (https://github.com/taskcluster/hubot-irc-alert)'
+    },
     json: true,
     query,
   });


### PR DESCRIPTION
This adds a user-agent that identifies this as tc-hubot, and also makes use of
the include_fields option. Using this option will make the bugzilla requests
much faster.